### PR TITLE
changing frontend port to 3000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,24 +2,26 @@ version: "3.8"
 services:
   nginx:
     image: nginx:latest
-    ports: 
+    ports:
       - "80:80"
-    volumes: 
-    - ./nginx:/etc/nginx/conf.d
-    depends_on: 
+    volumes:
+      - ./nginx:/etc/nginx/conf.d
+    depends_on:
       - frontend
       - activity-tracking
       - analytics
       - authservice
-    networks: 
+    networks:
       - app-network
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    environment: 
+    environment:
       - REACT_APP_API_GATEWAY_URL=nginx
+    ports:
+      - "3000:3000" # Change port mapping to 3000
     networks:
       - app-network
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,5 +14,5 @@ RUN npm test
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,5 @@
 upstream frontend {
-    server frontend:80;
+    server frontend:3000;
 }
 
 upstream activity_tracking {


### PR DESCRIPTION
To keep separate nginx and frontend ports, I have changed frontend port to 3000. Nginx will still remain at port 80. 