### PR TITLE
reverting frontend back to port 80

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       dockerfile: Dockerfile
     environment:
       - REACT_APP_API_GATEWAY_URL=nginx
-    ports:
-      - "3000:3000" # Change port mapping to 3000
     networks:
       - app-network
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,5 +14,5 @@ RUN npm test
 FROM nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 
-EXPOSE 3000
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,5 +1,5 @@
 upstream frontend {
-    server frontend:3000;
+    server frontend:80;
 }
 
 upstream activity_tracking {


### PR DESCRIPTION
I have reverted frontend back to port 80, as it was not working for Fargate with port 3000.