### PR TITLE
Adding unit testing for homepage.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "react-router-dom": "^6.16.0",
     "react-scripts": "5.0.1",
     "recharts": "^2.12.2",
-    "web-vitals": "^2.1.0"
+    "web-vitals": "^2.1.0",
+    "resize-observer-polyfill": "^1.5.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/homepage.js
+++ b/frontend/src/components/homepage.js
@@ -101,6 +101,7 @@ const Homepage = ({ currentUser }) => {
             }
         }
         } else {
+          calories.goal = 500;
           console.log('No response for calories goal.');
           }
   }, [caloriesResponse, caloriesGoalResponse, currentUser, todayDate]);
@@ -116,10 +117,10 @@ const Homepage = ({ currentUser }) => {
   return (
     <div className="Homepage-container">
       <h3 style={{ marginBottom: '30px'}}>🌟 Your Daily Summary 🌟</h3>
-      <h4 style={{ marginBottom: '20px'}}>Hello, {currentUser}!</h4>
+      <h4 data-testid="title" style={{ marginBottom: '20px'}}>Hello, {currentUser}!</h4>
       <p style={{ marginBottom: '10px'}}>How are you today?:</p>
       <div className="emojis" style={{ marginBottom: '25px'}}>
-        <IconButton className="emoji" color={selectedEmoji === 1 ? "primary" : "default"} onClick={() => updateBackgroundColor(1, '#83F0F3')}>
+        <IconButton className="emoji" data-testid="mood" color={selectedEmoji === 1 ? "primary" : "default"} onClick={() => updateBackgroundColor(1, '#83F0F3')}>
           <Mood fontSize='large' />
         </IconButton>
         <IconButton className="emoji" color={selectedEmoji === 2 ? "primary" : "default"} onClick={() => updateBackgroundColor(2, '#FBF071')}>
@@ -138,7 +139,7 @@ const Homepage = ({ currentUser }) => {
         <div>
         <p style={{marginBottom: "5px"}}>Your last exercise was on</p> 
         <p>{lastExercise.date}:</p>
-        <p style={{marginBottom: "5px"}}>Well done on {lastExercise.exercise}</p>
+        <p data-testid="lastEx" style={{marginBottom: "5px"}}>Well done on {lastExercise.exercise}</p>
         <p>for {lastExercise.duration} minutes!</p>
         <h4>👏👏👏</h4>
         </div>
@@ -166,7 +167,7 @@ const Homepage = ({ currentUser }) => {
           {/* Title */}
           <PolarAngleAxis
             type="number"
-            domain={[0, calories.value]}
+            domain={[0, calories.goal]}
             angleAxisId={0}
             tick={false}
           />

--- a/frontend/src/components/homepage.test.js
+++ b/frontend/src/components/homepage.test.js
@@ -1,0 +1,159 @@
+// This is a unit test file for the homepage.js component, it is using Jest and is being run by react-scripts.
+// The package.json has to be adapted to be able to run the tests successfully.
+// Docker is used to run the tests, the Frontend Dockerfile needs to contain the 'RUN npm test' command at the end of the build stage.
+// The tests will run AUTOMATICALLY when Docker is run, if the app build successfully then the tests have passed!!
+// The test cases should be updated when new features are added to the homepage.js file.
+// There has been difficulty mocking the GraphQL queries, so we have been unable to test functionality to do with the data.
+//
+// --- How to run the tests ---
+// To fix / add to the test file:
+// Change to frontend directory in terminal - 'cd frontend'.
+// Run docker command: 'docker compose run --build --rm frontend test'
+// If they pass, you will not see outcome of tests in the terminal.
+// If they fail, the test results will be shown in the terminal.
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { MockedProvider } from "@apollo/client/testing";
+import '@testing-library/jest-dom';
+import Homepage from './homepage';
+import { LAST_EXERCISE_QUERY, CALORIES_QUERY, CALORIES_GOAL_QUERY} from './queries/graphql';
+import { expect } from '@jest/globals';
+import { BrowserRouter } from 'react-router-dom';
+
+jest.mock('recharts', () => {
+    const OriginalModule = jest.requireActual('recharts')
+    return {
+        ...OriginalModule,
+        ResponsiveContainer: ({ children }) => (
+            <OriginalModule.ResponsiveContainer width={800} height={800}>
+                {children}
+            </OriginalModule.ResponsiveContainer>
+        ),
+    }
+})
+
+global.ResizeObserver = require("resize-observer-polyfill");
+
+const mocks = [
+    {
+        request: {
+            query: LAST_EXERCISE_QUERY,
+            variables: {
+                name: "testUser"
+            }
+        },
+        result: {
+            data: {
+                homePage: {
+                    results: {
+                        _id: 0,
+                        exercise: "Running",
+                        duration: 60,
+                        date: "05-04-2024"
+                    }
+                }
+            }
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY
+    },
+    {
+        request: {
+            query: CALORIES_QUERY,
+            variables: {
+                name: "testUser",
+                today_date: "05-04-2024"
+            }
+        },
+        result: {
+            data: {
+                dailyCalories: {
+                    results: {
+                        _id: 0,
+                        daily_calories: 315
+                    }
+                }
+            }
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY
+    },
+    {
+        request: {
+            query: CALORIES_GOAL_QUERY,
+            variables: {
+                name: "testUser"
+            }
+        },
+        result: {
+            data: {
+                caloriesGoal: {
+                    results: {
+                        _id: 0,
+                        value: 600
+                    }
+                }
+            }
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY
+    }
+
+];
+
+describe('Homepage Component', () => {
+
+  test('renders the component', async () => {
+
+    const { container } = render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <BrowserRouter>
+            <Homepage currentUser="testUser" today_date="05-04-2024" />
+            </BrowserRouter>
+        </MockedProvider>
+    );
+    await expect(container).toBeInTheDocument();
+
+  });
+
+  test('personalised title with users name', () => {
+    const { getByTestId } = render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <BrowserRouter>
+            <Homepage currentUser="testUser" today_date="05-04-2024" />
+            </BrowserRouter>
+        </MockedProvider>
+    );
+    const title = getByTestId('title');
+    expect(title.textContent).toBe('Hello, testUser!');
+  });
+
+//   test('users last exercise is rendered', async () => {
+//     const {getByTestId } = render(
+//         <MockedProvider mocks={mocks} addTypename={false}>
+//             <BrowserRouter>
+//             <Homepage currentUser="testUser" today_date="05-04-2024" />
+//             </BrowserRouter>
+//         </MockedProvider>
+//     );
+
+//     const lastExField = await waitFor(() => getByTestId('lastEx'));
+
+//     expect(lastExField.textContent).toBe('Well done on Running');
+
+//   });
+
+// Test not working - can't get the chart to render properly within the test.
+//   test('clicking emoji changes colour theme', async () => {
+//     const { getByTestId } = render(
+//         <MockedProvider mocks={mocks} addTypename={false}>
+//             <BrowserRouter>
+//             <Homepage currentUser="testUser" today_date="05-04-2024" />
+//             </BrowserRouter>
+//         </MockedProvider>
+//     );
+//     fireEvent.click(getByTestId('mood'));
+
+//     const chart = getByTestId('chart');
+//     expect(await chart.fill.toBe('#83F0F3'));
+//   });
+
+});

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "MLA-pilot-group-2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
New unit test file - homepage.test.js:
- Tests the correct rendering of the homepage.
- Tests the personalisation of the title.
- Mocks the graphQL queries.
- Unable to test data functionality, or change in colour theme (as can't render chart properly) - nothing I tried worked, despite finding multiple stack overflow resolutions :(

- Changes to package.json file required to install object resolver for attempt at recharts rendering.